### PR TITLE
Output correct timestamp. Was being truncated incorrectly.

### DIFF
--- a/src/dump1090.c
+++ b/src/dump1090.c
@@ -2593,7 +2593,7 @@ static const char *get_SBS_timestamp (void)
   strcat (timestamp, ts_buf);
 
   if (ts_len >= 1)
-     timestamp [ts_len - 1] = '\0';    /* remove last ',' */
+     timestamp [strlen(timestamp) - 1] = '\0';    /* remove last ',' */
   return (timestamp);
 }
 


### PR DESCRIPTION
Hi, I've just tried to use the latest version and noticed that there is a bug in this method.
ts_len is set to 24, the result of the snprintf which contains a single date and time combination ("2024/06/28,22:07:09.657,"). 
This value is then copied and appended (so it becomes "2024/06/28,22:07:09.657,2024/06/28,22:07:09.657,") which conforms to the SBS spec, but ts_len is still 24 and doesn't take the duplicated value into account, so when we assign the null terminator it removes the second date and time fields (thus shifting the columns to the left by 2).
I've added the call to strlen(timestamp) but if you have a better way of accomplishing this then feel free to amend (ts_len * 2 - 1?)