### PR TITLE
Adding guards against division by 0

### DIFF
--- a/src/interactive.c
+++ b/src/interactive.c
@@ -1285,8 +1285,8 @@ static bool mouse_pos (HWND wnd, POINT *pos)
   if (!con_wnd || !GetCursorPos(pos) || !ScreenToClient(wnd, pos))
      return (false);
 
-  pos->x /= x_scale;
-  pos->y /= y_scale;
+  if (x_scale > 0) pos->x /= x_scale;
+  if (y_scale > 0) pos->y /= y_scale;
   return (true);
 }
 


### PR DESCRIPTION
When attempting to run under Windows in interactive mode, x_scale and y_scale were coming out at 0 and thus throwing an integer division by 0 exception. Added guards on x_scale and y_scale to only attempt division where their values are greater than 0.