### PR TITLE
Fix SDRplay RSP2 SC16 sample handling for ADS-B decoding

### DIFF
--- a/src/demod-8000.c
+++ b/src/demod-8000.c
@@ -117,6 +117,8 @@ void demod_8000_free (void)
  */
 void demod_8000 (const mag_buf *mag)
 {
+  TRACE("demod_8000 called, valid_length: %u, overlap: %u\n",
+        mag->valid_length, mag->overlap);
   modeS_message   mm;
   uint8_t         msg      [MODES_LONG_MSG_BYTES + D8M_SEARCH_BYTES];
   uint8_t         best_msg [MODES_LONG_MSG_BYTES];
@@ -129,7 +131,7 @@ void demod_8000 (const mag_buf *mag)
   int            *dbuf;
   int             i, sum;
   int             message_result;
-  u_int           j, mlen = mag->valid_length - mag->overlap;
+  u_int           j, mlen = mag->valid_length;
   const uint16_t *m = mag->data;
 
   /* local variables initialized from static storage
@@ -199,6 +201,10 @@ void demod_8000 (const mag_buf *mag)
     phase_av_acc += phase[0];
     phase_av = phase_av_acc >> 14;          /* phase_av is current output */
     phase_av_acc -= phase_av;               /* phase_av_acc is filter memory */
+
+    if (sptr == 40000)  /* print occasionally */
+        TRACE("max: %d, phase_av: %d, ratio: %d%%\n",
+            max, phase_av, phase_av ? (max * 200 / phase_av) : 0);
 
     /* This code first triggers when max exceeds noise by given factor.
      * Once triggered, it continues for 0 <= window < WIN_LEN, ie

--- a/src/dump1090.c
+++ b/src/dump1090.c
@@ -724,8 +724,8 @@ static bool modeS_init_hardware (void)
     Modes.bytes_per_sample = 4;
   }
 
-  if (!fifo_init(Modes.FIFO_bufs, MODES_MAG_BUF_SAMPLES + Modes.trailing_samples, Modes.trailing_samples))
-  {
+  unsigned mag_buf_samples = MODES_ASYNC_BUF_SIZE / Modes.bytes_per_sample;
+  if (!fifo_init(Modes.FIFO_bufs, mag_buf_samples + Modes.trailing_samples, Modes.trailing_samples)) {
     LOG_STDERR ("Out of memory allocating FIFO\n");
     return (false);
   }
@@ -1158,7 +1158,9 @@ void rx_callback (uint8_t *in_buf, uint32_t in_len, void *ctx)
      * this is valid pointer arithmetics. But what about SDRPlay?
      */
     out_buf->valid_length = out_buf->overlap + to_convert;
-
+    TRACE("to_convert: %u, in_len: %u, bytes_per_sample: %u\n",
+        to_convert, in_len, Modes.bytes_per_sample);
+    TRACE("converter: %s\n", Modes.converter_state->func_name);
     (*Modes.converter_func) (in_buf, &out_buf->data [out_buf->overlap], to_convert,
                              Modes.converter_state, &out_buf->mean_power);
 

--- a/src/externals/SDRplay/sdrplay.c
+++ b/src/externals/SDRplay/sdrplay.c
@@ -12,20 +12,22 @@
 #define MODES_RSP_BUF_SIZE   (256*1024)   /**< 256k, same as MODES_ASYNC_BUF_SIZE */
 #define MODES_RSP_BUFFERS     16          /**< Must be power of 2 */
 
-#define RSP_MIN_GAIN_THRESH   512         /**< Increase gain if peaks below this */
-#define RSP_MAX_GAIN_THRESH  1024         /**< Decrease gain if peaks above this */
 #define RSP_ACC_SHIFT          13         /**< Sets time constant of averaging filter */
 #define MODES_RSP_INITIAL_GR   20
-#define USE_8BIT_SAMPLES        1
+#define USE_8BIT_SAMPLES        0
 
 #if USE_8BIT_SAMPLES
-  #define SAMPLE_SCALE(x)   (((x) + 32) >> 6)  /* from 14 to 8 bit */
-  #define SAMPLE_TYPE       uint8_t
-  #define SAMPLE_TYPE_STR  "uint8_t"
+  #define SAMPLE_SCALE(x)      (((x) + 32) >> 6)  /* from 14 to 8 bit */
+  #define SAMPLE_TYPE          uint8_t
+  #define SAMPLE_TYPE_STR     "uint8_t"
+  #define RSP_MIN_GAIN_THRESH  512    /**< Increase gain if peaks below this */
+  #define RSP_MAX_GAIN_THRESH  1024   /**< Decrease gain if peaks above this */
 #else
-  #define SAMPLE_SCALE(x)   x
-  #define SAMPLE_TYPE       uint16_t
-  #define SAMPLE_TYPE_STR  "uint16_t"
+  #define SAMPLE_SCALE(x)      (x)   /* pass raw signed 16-bit samples through */
+  #define SAMPLE_TYPE          uint16_t
+  #define SAMPLE_TYPE_STR     "uint16_t"
+  #define RSP_MIN_GAIN_THRESH  512    /**< Increase gain if peaks below this */
+  #define RSP_MAX_GAIN_THRESH  1024   /**< Decrease gain if peaks above this */
 #endif
 
 /**
@@ -556,8 +558,12 @@ static void sdrplay_callback_A (short                       *xi,
   }
 
   /* Apply slowly decaying filter to max signal value
-   */
+ */
+#if USE_8BIT_SAMPLES
   max_sig -= 127;
+#else
+  max_sig = abs(max_sig);
+#endif
   max_sig_acc += max_sig;
   max_sig = max_sig_acc >> RSP_ACC_SHIFT;
   max_sig_acc -= max_sig;
@@ -618,7 +624,9 @@ static void sdrplay_callback_A (short                       *xi,
     end &= ~(MODES_RSP_BUF_SIZE - 1);
 
     sdr.rx_num_callbacks++;
-    (*sdr.rx_callback) ((uint8_t*)sdr.rx_data + end, MODES_RSP_BUF_SIZE, sdr.rx_context);
+    (*sdr.rx_callback) ((uint8_t*)sdr.rx_data + end * sizeof(SAMPLE_TYPE),
+        MODES_RSP_BUF_SIZE * sizeof(SAMPLE_TYPE),
+        sdr.rx_context);
   }
 
   /* Stash static values in `sdr` struct
@@ -778,22 +786,38 @@ static int sdrplay_init_async (sdrplay_dev *device,
   }
 
 #if USE_8BIT_SAMPLES
-  Modes.input_format     = INPUT_UC8;   /* Unsigned, Complex, 8 bit per sample. Always */
+  Modes.input_format = INPUT_UC8;   /* Unsigned, Complex, 8 bit per sample. Always */
   Modes.bytes_per_sample = 2;
-  Modes.measure_noise    = false;
-  Modes.DC_filter        = false;
-
-  TRACE ("Reinit for USE_8BIT_SAMPLES == 1\n");
-  Modes.converter_func = convert_init (Modes.input_format,
-                                       Modes.sample_rate,
-                                       Modes.DC_filter,
-                                       Modes.measure_noise,   /* total power is interesting if we want noise */
-                                       &Modes.converter_state);
+  Modes.measure_noise = false;
+  Modes.DC_filter = false;
+  TRACE("Reinit for USE_8BIT_SAMPLES == 1\n");
+  Modes.converter_func = convert_init(Modes.input_format,
+      Modes.sample_rate,
+      Modes.DC_filter,
+      Modes.measure_noise,   /* total power is interesting if we want noise */
+      &Modes.converter_state);
   if (!Modes.converter_func)
   {
-    strcpy_s (sdr.last_err, sizeof(sdr.last_err), "Reinit of sample converter failed");
-    sdr.last_rc = sdrplay_api_Fail;   /* a better error-code? */
-    return (sdr.last_rc);
+      strcpy_s(sdr.last_err, sizeof(sdr.last_err), "Reinit of sample converter failed");
+      sdr.last_rc = sdrplay_api_Fail;   /* a better error-code? */
+      return (sdr.last_rc);
+  }
+#else
+  Modes.input_format = INPUT_SC16;  /* Signed, Complex, 16 bit per sample. Always */
+  Modes.bytes_per_sample = 4;
+  Modes.measure_noise = false;
+  Modes.DC_filter = false;
+  TRACE("Reinit for USE_8BIT_SAMPLES == 0, using SC16\n");
+  Modes.converter_func = convert_init(Modes.input_format,
+      Modes.sample_rate,
+      Modes.DC_filter,
+      Modes.measure_noise,
+      &Modes.converter_state);
+  if (!Modes.converter_func)
+  {
+      strcpy_s(sdr.last_err, sizeof(sdr.last_err), "Reinit of sample converter failed");
+      sdr.last_rc = sdrplay_api_Fail;
+      return (sdr.last_rc);
   }
 #endif
 
@@ -822,7 +846,8 @@ static int sdrplay_init_async (sdrplay_dev *device,
   if (sdr.chosen_dev->hwVer != SDRPLAY_RSP1_ID)
      sdr.ch_params->tunerParams.gain.minGr = sdrplay_api_EXTENDED_MIN_GR;
 
-  sdr.ch_params->ctrlParams.agc.enable = Modes.dig_agc;
+  sdr.ch_params->ctrlParams.agc.enable = Modes.dig_agc ? sdrplay_api_AGC_CTRL_EN : sdrplay_api_AGC_DISABLE;
+  sdr.ch_params->ctrlParams.agc.setPoint_dBfs = -45;
 
   sdr.ch_params->tunerParams.gain.gRdB     = sdr.gain_reduction;
   sdr.ch_params->tunerParams.gain.LNAstate = 0;


### PR DESCRIPTION
DISCLAIMER:  

This was all vibe coding over an afternoon with Claude as I'm by no means a coding or github expert.  As such, it's probably a hot mess so you can take it or leave it (probably leave it).    It was mainly just as a learning experience for me but if it can further the cause then that would be cool.

I think it has progressed _slightly_ from where I started.   It is making some attempt to decode and putting the odd plane on the  map but I'm consistently getting 2-bit errors.  The AGC still doesn't seem to be working consistently but it's making an effort.  Also the number of decoded messages seems to be VERY low compared to the mutability/sdrplay version.

I am seeing some valid pre-ambles which I wasn't to start with and the occasional message comes through properly.

-----------



gvanem/Dump1090 SDRplay RSP2 Fix Attempt — Summary
Hardware

SDRplay RSP2 Pro, API 3.15, Windows 10/11
Antenna port B, 8MS/s sample rate
Reference: sdrplay/dump1090 (mutability fork) works correctly with identical hardware

Root Cause Identified
The original code used #define USE_8BIT_SAMPLES 1 which caused the SDRplay's native SC16 (signed 16-bit) samples to be incorrectly converted to 8-bit unsigned before demodulation. The mutability fork uses SC16 samples directly.

Changes Made to Source Files
src/externals/SDRplay/sdrplay.c

USE_8BIT_SAMPLES changed from 1 to 0
SAMPLE_SCALE macro updated for 16-bit path:

c#if USE_8BIT_SAMPLES
  #define SAMPLE_SCALE(x)      (((x) + 32) >> 6)
  #define SAMPLE_TYPE          uint8_t
  #define SAMPLE_TYPE_STR     "uint8_t"
  #define RSP_MIN_GAIN_THRESH  512
  #define RSP_MAX_GAIN_THRESH  1024
#else
  #define SAMPLE_SCALE(x)      (x)
  #define SAMPLE_TYPE          uint16_t
  #define SAMPLE_TYPE_STR     "uint16_t"
  #define RSP_MIN_GAIN_THRESH  512
  #define RSP_MAX_GAIN_THRESH  1024
#endif

Added SC16 initialisation path alongside existing UC8 path:

c#if USE_8BIT_SAMPLES
  Modes.input_format     = INPUT_UC8;
  Modes.bytes_per_sample = 2;
  Modes.measure_noise    = false;
  Modes.DC_filter        = false;
  TRACE("Reinit for USE_8BIT_SAMPLES == 1\n");
  Modes.converter_func = convert_init(...);
  if (!Modes.converter_func) { ... return error; }
#else
  Modes.input_format     = INPUT_SC16;
  Modes.bytes_per_sample = 4;
  Modes.measure_noise    = false;
  Modes.DC_filter        = false;
  TRACE("Reinit for USE_8BIT_SAMPLES == 0, using SC16\n");
  Modes.converter_func = convert_init(...);
  if (!Modes.converter_func) { ... return error; }
#endif

Fixed rx_callback buffer pointer and length to account for 16-bit sample size:

c(*sdr.rx_callback) ((uint8_t*)sdr.rx_data + end * sizeof(SAMPLE_TYPE),
                    MODES_RSP_BUF_SIZE * sizeof(SAMPLE_TYPE),
                    sdr.rx_context);

Fixed max_sig filter to use abs() for signed 16-bit samples:

c#if USE_8BIT_SAMPLES
  max_sig -= 127;
#else
  max_sig = abs(max_sig);
#endif

Fixed AGC enable to use correct SDRplay API enum value and setpoint:

csdr.ch_params->ctrlParams.agc.enable = Modes.dig_agc ?
    sdrplay_api_AGC_CTRL_EN : sdrplay_api_AGC_DISABLE;
sdr.ch_params->ctrlParams.agc.setPoint_dBfs = -30;

src/dump1090.c

Fixed FIFO magnitude buffer size to correctly account for bytes per sample:

cunsigned mag_buf_samples = MODES_ASYNC_BUF_SIZE / Modes.bytes_per_sample;
if (!fifo_init(Modes.FIFO_bufs, mag_buf_samples + Modes.trailing_samples,
               Modes.trailing_samples))

src/demod-8000.c

Fixed mlen to process full buffer including overlap (matching mutability behaviour):

cu_int j, mlen = mag->valid_length;  /* was: mag->valid_length - mag->overlap */

Current State

SC16 converter confirmed active (convert_sc16_nodc_nopower)
demod_8000 being called correctly with proper buffer sizes
Real Australian ICAO addresses detected intermittently (e.g. 7190F1, 67319C, C219E9)
AGC settles around gRdB=48-51 with setPoint_dBfs = -30

Remaining Issues

All decoded messages still require 2-bit error correction — no clean CRC passes
Message rate much lower than mutability fork
AGC behaviour still not fully stable — max_sig tracking using raw xi[] values may not be appropriate for SC16 samples
phase_av in demod_8000 converges too close to max — insufficient signal-to-noise separation to reliably detect preambles

Suspected Remaining Root Cause
The max_sig accumulator in sdrplay_callback_A was designed for 8-bit unsigned samples. Even with abs(max_sig) the values being tracked from raw signed xi[] samples don't behave equivalently to the 8-bit path, affecting both the gain display metric and indirectly the AGC feedback loop. The demod_8000 trigger threshold and phase_av filter were also tuned for 8-bit magnitude values and may need adjustment for the SC16 magnitude range produced by convert_sc16_nodc_nopower.