### PR TITLE
Fix ghost aircraft from unvalidated CRC-corrected DF17/18 and DF24-31 addresses

### DIFF
--- a/src/dump1090.c
+++ b/src/dump1090.c
@@ -2375,15 +2375,40 @@ static int _decode_mode_S_message (modeS_message *mm, const uint8_t *_msg)
     case 4:  /* Surveillance, altitude reply */
     case 5:  /* Surveillance, altitude reply */
     case 16: /* Long air-air surveillance */
+    case 24: /* Comm-D (ELM) */
+    case 25: /* Comm-D (ELM) */
+    case 26: /* Comm-D (ELM) */
+    case 27: /* Comm-D (ELM) */
+    case 28: /* Comm-D (ELM) */
+    case 29: /* Comm-D (ELM) */
+    case 30: /* Comm-D (ELM) */
+    case 31: /* Comm-D (ELM) */
          /* These message types use Address/Parity, i.e. our CRC syndrome is the sender's ICAO address.
           * We can't tell if the CRC is correct or not as we don't know the correct address.
-          * Accept the message if it appears to be from a previously-seen aircraft
+          * Accept the message if it appears to be from a previously-seen aircraft.
+          *
+          * FIX: DF24-31 (Comm-D/ELM) used to be handled in a separate switch
+          * arm further down with NO ICAO_FILTER_TEST() check at all -- any
+          * message with this DF, however corrupted, was accepted
+          * unconditionally via `mm->addr = mm->CRC`, then persisted as a
+          * brand-new aircraft with zero validation (aircraft_create() in
+          * aircraft.c performs no plausibility checks of its own -- this
+          * function is the only gate in the whole pipeline). Merged into
+          * this branch so DF24-31 gets the same gate as DF0/4/5/16 -- which
+          * also matches mutability's decodeModesMessage() and this fork's
+          * own modeS_message_score(), both of which already group case 24
+          * here.
           */
          if (!ICAO_FILTER_TEST(mm->CRC))
             return (-1);
 
          mm->addr = mm->CRC;
          mm->reliable = false;
+         if (mm->msg_type >= 24)
+         {
+           mm->msg_type = 24;   /* remap DF25-31 to a single DF24 for simplicity */
+           mm->source   = SOURCE_MODE_S;
+         }
          break;
 
     case 11: /* All-call reply */
@@ -2423,9 +2448,22 @@ static int _decode_mode_S_message (modeS_message *mm, const uint8_t *_msg)
 
     case 17:   /* Extended squitter */
     case 18:   /* Extended squitter/non-transponder */
-         mm->reliable = (mm->error_bits == 0);
+         /* FIX: `mm->reliable` used to be set here unconditionally, using
+          * `mm->error_bits` *before* it gets assigned the real correction
+          * count a few lines below (it's reset to 0 for every message type
+          * further up, and only overwritten with `ei->errors` after this
+          * point). That meant `reliable` was unconditionally `(0 == 0)` ==
+          * true for every single DF17/18 message, clean or not -- exactly
+          * the message types carrying position/altitude/identification.
+          * Moved to the end of this case, after `error_bits` is actually
+          * known, so a message that needed correction is no longer
+          * mislabeled as reliable.
+          */
          if (mm->CRC == 0)
-            break;  /* all good */
+         {
+           mm->reliable = true;   /* genuinely clean, 0 corrections needed */
+           break;
+         }
 
          ei = crc_checksum_diagnose (mm->CRC, mm->msg_bits);
          if (!ei)
@@ -2438,9 +2476,30 @@ static int _decode_mode_S_message (modeS_message *mm, const uint8_t *_msg)
 
          /* We are conservative here: only accept corrected messages that
           * match an existing aircraft.
+          *
+          * FIX: this must NOT be conditional on `addr1 != addr2`. A 2-bit
+          * CRC "fix" only means *some* 2-bit flip zeroes the syndrome; per
+          * crc.c's own ~35% false-positive rate for 2-bit correction, a
+          * coincidental syndrome match can be entirely wrong even when the
+          * bits it happens to flip are outside the address field (bits
+          * 8-31). In that case addr1 == addr2, so the old `addr1 != addr2`
+          * guard never re-validated the address at all -- letting an
+          * unverified, possibly fabricated address straight through.
+          * Confirmed empirically against a live capture: 9/9 flagged ghost
+          * ICAOs were DF17 messages with 2-bit corrections whose
+          * corrected-bit positions were both outside 8-31.
+          *
+          * Single-bit corrections keep the original `addr1 != addr2`
+          * behaviour, since crc.c's single-bit syndrome space has
+          * essentially no collision risk -- only 2-bit correction carries
+          * the documented ambiguity that makes this necessary.
           */
-         if (addr1 != addr2 && !ICAO_FILTER_TEST(addr2))
+         if (mm->error_bits == 2 && !ICAO_FILTER_TEST(addr2))
             return (-1);
+         if (mm->error_bits == 1 && addr1 != addr2 && !ICAO_FILTER_TEST(addr2))
+            return (-1);
+
+         mm->reliable = (mm->error_bits == 0);
          break;
 
     case 20: /* Comm-B, altitude reply */
@@ -2473,24 +2532,6 @@ static int _decode_mode_S_message (modeS_message *mm, const uint8_t *_msg)
          }
 #endif
          return (-1); /* no good */
-
-    case 24: /* Comm-D (ELM) */
-    case 25: /* Comm-D (ELM) */
-    case 26: /* Comm-D (ELM) */
-    case 27: /* Comm-D (ELM) */
-    case 28: /* Comm-D (ELM) */
-    case 29: /* Comm-D (ELM) */
-    case 30: /* Comm-D (ELM) */
-    case 31: /* Comm-D (ELM) */
-        /* These messages use Address/Parity,
-         * and also use some of the DF bits to carry data. Remap them all to a single
-         * DF for simplicity.
-         */
-        mm->msg_type = 24;
-        mm->source   = SOURCE_MODE_S;
-        mm->addr     = mm->CRC;
-        mm->reliable = false;
-        break;
 
     default:
          /* All other message types, we don't know how to handle their CRCs, give up


### PR DESCRIPTION
## Problem

Running against a live SDRplay RSP2 capture, `aircraft.c`'s `aircraft_create()`
was creating and persisting aircraft entries for ICAO addresses that had never
actually been seen — no matching registration, no plausible track, and no
independent corroboration. Over one overnight session this inflated
`Modes.stat.unique_aircrafts` to over 21,000 — implausible for the traffic
volume in the area. These entries reached network clients (e.g. VRS over
`sbs_out`) but never appeared on the built-in tar1090 map, since they never
acquired a valid position — they were being created, just never plotted.

`aircraft_create()` itself performs no plausibility checks (confirmed by
reading `aircraft.c`) — it's a pure create-on-demand table. That makes
`_decode_mode_S_message()` in `dump1090.c` the only real gate in the whole
pipeline, so both fixes below are there.

## Root cause 1: DF17/18 address re-validation only fires when the correction changed the address bytes

```c
if (addr1 != addr2 && !ICAO_FILTER_TEST(addr2))
    return (-1);
```

A "successful" 2-bit CRC correction doesn't mean *only* those 2 bits were
wrong — per `crc.c`'s own documented ~35% false-positive rate for 2-bit
correction, a coincidental syndrome match can validate an entirely corrupted
message. If the 2 corrected bits happen to fall outside the address field
(bits 8-31 of the message), `addr1 == addr2`, so this guard never
re-validates the address at all — even though nothing about "the correction
missed the address bytes" implies the address bytes are actually correct.

**Confirmed empirically**: I flagged 9 recurring, never-before-seen ICAOs
appearing in VRS with implausible altitude/track data. Cross-referencing
against a `--debug g` capture, all 9 were DF17 messages with 2-bit
corrections whose corrected-bit positions were *both* outside 8-31 in every
single case:

| ICAO | Corrected bits |
|---|---|
| 6BFC00 | 45, 63 |
| D2C7F2 | 70, 89 |
| D0947E | 60, 104 |
| 564785 | 57, 64 |
| 21A0AE | 36, 65 |
| 0AAF6D | 34, 106 |
| 2D6B38 | 87, 98 |
| 1935B3 | 81, 100 |
| 848F35 | 38, 86 |

**Fix**: gate on `mm->error_bits == 2` directly, independent of whether the
address bytes moved. Single-bit corrections keep the original
`addr1 != addr2` behaviour, since the single-bit syndrome space has
essentially no collision risk — this fix is scoped specifically to the
ambiguous 2-bit case `crc.c` already documents.

## Root cause 2: DF24-31 (Comm-D/ELM) has no address validation at all

The previous code accepted any DF24-31 message unconditionally:

```c
mm->addr = mm->CRC;   // no ICAO_FILTER_TEST() at all
```

This is inconsistent with mutability's `decodeModesMessage()`, which groups
`case 24` with `case 0/4/5/16` under the same `icaoFilterTest()` gate — and
inconsistent with this fork's *own* `modeS_message_score()`, which already
groups `case 24` the same way. This looks like an inconsistency introduced
between the two functions rather than an intentional design choice.

**Fix**: merged DF24-31 into the same protected branch as DF0/4/5/16.

## Bonus fix: `mm->reliable` set before `error_bits` is known

```c
mm->reliable = (mm->error_bits == 0);   // error_bits is still 0 here, always
if (mm->CRC == 0)
    break;
...
mm->error_bits = ei->errors;   // set afterward -- too late
```

This made `reliable` unconditionally `true` for every DF17/18 message
regardless of correction. Moved the assignment to after `error_bits` is
actually known.

## Testing

- Clean build (MSBuild, x64/Release) against current `main`.
- Not yet re-run overnight against live traffic — will follow up with
  before/after `unique_aircrafts` counts once I have a few hours of data on
  the fixed build.

## Note

This supersedes #46, which I opened a few weeks ago with an earlier, much
rougher attempt at the SDRplay decode issues on the same hardware. I'll
close that one in favour of this, since the underlying code has moved on
significantly since then.