### PR TITLE
demod-8000.c: fix RSSI (was never populated) and correct MLAT timestamp offset

### DIFF
--- a/src/demod-8000.c
+++ b/src/demod-8000.c
@@ -389,6 +389,13 @@ void demod_8000 (const mag_buf *mag)
           Modes.stat.valid_preamble++;
           mm.AC_flags = mm.error_bits = 0;
 
+          /* `msglen`/`signal_len` used below for both the MLAT timestamp
+           * correction and the RSSI measurement further down -- computed
+           * once here so both stay consistent.
+           */
+          int msglen = modeS_message_len_by_type (best_msg[0] >> 3);
+          int signal_len = msglen * D8M_NUM_PHASES;
+
           /* Set initial mm structure details
            *
            * `mag->sample_timestamp` marks the start of the *new*
@@ -397,9 +404,22 @@ void demod_8000 (const mag_buf *mag)
            * the old overlap tail -- see the correction above),
            * so it needs `mag->overlap` subtracted to be relative
            * to the new-data start that `sample_timestamp` marks.
+           *
+           * MLAT FIX (same root cause as the RSSI fix further down,
+           * applied here by the same reasoning but NOT independently
+           * verified -- neither of us runs MLAT, so this hasn't been
+           * checked end-to-end against a real multilateration setup;
+           * flagging for anyone who does to confirm): live testing while
+           * fixing RSSI below showed `position` consistently marks the
+           * END of the decoded message, not the start (`dptr` walks
+           * forward through the full byte-extraction before the small
+           * `-64+i*8` adjustment, so it can't represent anything but a
+           * point near the end of that walk). MLAT timestamps should
+           * mark the message's start, so the same `- signal_len`
+           * correction used for the RSSI window is applied here too.
            */
           mm.timestamp_msg = mag->sample_timestamp +
-              (position - D8M_LOOK_AHEAD - (int) mag->overlap) * 12 / 8;
+              (position - D8M_LOOK_AHEAD - signal_len - (int) mag->overlap) * 12 / 8;
 
           /* compute message receive time as block-start-time + difference in the 12MHz clock
            */
@@ -410,6 +430,59 @@ void demod_8000 (const mag_buf *mag)
           /* Decode the received message
            */
           message_result = decode_mode_S_message (&mm, best_msg);
+
+          if (message_result >= 0)
+          {
+            /* Measure signal power for RSSI.
+             *
+             * Adapted from demod-2400.c's pattern, but NOT a direct port --
+             * several things differ at 8 MS/s / in this function's own
+             * coordinate system:
+             *
+             * 1) `position` (not `j`, which demod-2400.c uses but which
+             *    isn't meaningful here) tracks this message's location,
+             *    in the same `dbuf`-relative coordinate system already
+             *    used for the MLAT timestamp above.
+             * 2) `signal_len` uses D8M_NUM_PHASES (8 samples/bit at 8 MS/s)
+             *    directly -- demod-2400.c's `*12/5` ratio is specific to
+             *    its own 2.4 MS/s sampling and doesn't apply here.
+             * 3) Normalizing by `65535.0 * 65535.0` (squared, matching
+             *    `_mag * _mag` being a squared magnitude), not a single
+             *    `65535.0` -- the single-division version overstates
+             *    signal power by a factor of 65535.
+             * 4) `position - D8M_LOOK_AHEAD` alone maps to the *end* of
+             *    the message, not the start (confirmed by directly
+             *    inspecting the raw magnitude data around candidate
+             *    windows during testing) -- the extra `- signal_len`
+             *    steps back to the message's actual start.
+             *
+             * Unlike `dbuf` (which has D8M_LOOK_BACK/D8M_LOOK_AHEAD margin
+             * deliberately built in), `m` is the raw per-call buffer with
+             * no look-back headroom -- an unchecked read here can run
+             * outside its valid range. Bounds-checked below: if the
+             * mapped range falls outside [0, mlen), skip the measurement
+             * for this message rather than read out of bounds. sig_level
+             * stays at its memset default (0), and aircraft.c already
+             * only records a signal sample when sig_level > 0, so this
+             * message simply won't contribute an RSSI sample this time.
+             */
+            int m_start = position - D8M_LOOK_AHEAD - signal_len;
+
+            if (m_start >= 0 && m_start + signal_len <= mlen)
+            {
+              double   signal_power;
+              uint64_t scaled_signal_power = 0;
+              int      k;
+
+              for (k = 0; k < signal_len; k++)
+              {
+                uint32_t _mag = m [m_start + k];
+                scaled_signal_power += _mag * _mag;
+              }
+              signal_power = scaled_signal_power / 65535.0 / 65535.0;
+              mm.sig_level = signal_power / signal_len;
+            }
+          }
 
           if (mm.addr && message_result >= 0)
              modeS_user_message (&mm);


### PR DESCRIPTION
# Fix demod_8000() RSSI (was never populated) + correct MLAT timestamp offset

## Summary

Two related fixes, both stemming from the same root-cause finding about
what `position` actually represents in `demod_8000()`.

### 1. RSSI was never populated for the SDRplay 8MHz path

`mm.sig_level` was never set anywhere in `demod_8000()` -- `mm` is
`memset` to all-zero at the top of the function and nothing in the 8MHz
path ever wrote to that field. Downstream, `aircraft_update_from_message()`
in `aircraft.c` only records a signal sample when `mm->sig_level > 0`:

```c
if (mm->sig_level > 0)
{
  a->sig_levels [a->sig_idx++] = mm->sig_level;
  a->sig_idx &= DIM(a->sig_levels) - 1;
}
```

So every SDRplay-decoded aircraft's `sig_levels[]` buffer stayed at its
initial filler value, and the `"rssi"` field sent to the web UI
(`web-send-rssi` in the cfg) was meaningless for SDRplay users -- this
is what prompted the investigation (tar1090 showing implausible/empty
RSSI, reported against PR #58).

**Fix:** added a signal-power measurement modelled on `demod-2400.c`'s
existing pattern, adapted for 8 MS/s (see code comments for the specific
differences -- sample-rate ratio, normalization, and the `position`
offset described below). Bounds-checked against `m[]` (the raw per-call
magnitude buffer, which unlike `dbuf` has no look-back margin) so an
out-of-range read is skipped rather than undefined behaviour.

### 2. `position` marks the end of the message, not the start

While chasing the RSSI fix, an initial attempt (mirroring
`demod-2400.c`'s offset convention) produced RSSI values that were both
implausible in magnitude and -- more tellingly -- **nearly identical
regardless of real distance or message type**: strong/close and
weak/distant aircraft alike clustered within a fraction of a dB of each
other, which is what you'd expect from reading background noise, not
real signal.

To find out why, I added a temporary diagnostic that dumped a wide
window of raw magnitude samples (+/-4000 samples, bucketed) around the
computed read position for many real messages. Consistently, across
many aircraft and both near and far ranges, the real signal burst sat
entirely *before* the window we were reading, ending almost exactly
where the read window began. That is: `position - D8M_LOOK_AHEAD` maps
to the *end* of the decoded message, not the start -- which makes sense
given `dptr` walks forward through the entire byte-extraction loop
before the final `-64+i*8` adjustment, so it can't represent anything
but a point near the end of that walk.

**Fix (RSSI):** `m_start = position - D8M_LOOK_AHEAD - signal_len`, not
`position - D8M_LOOK_AHEAD`.

**Fix (MLAT, same root cause):** the existing `mm.timestamp_msg`
calculation uses the same uncorrected `position - D8M_LOOK_AHEAD`
expression, so it likely has the same systematic error -- MLAT
timestamps should mark a message's start, and up to ~112us off (one
long-message duration) for every message seems like it would matter for
multilateration accuracy. Applied the same `- signal_len` correction
there.

## Evidence

RSSI, after both fixes, tested against multiple real aircraft at
different (if not perfectly clean radial) ranges in one session:

```
ICAO       n    min     max    avg   spread
7C02FF   429  -47.4   -21.2  -31.6    26.2   (aircraft with changing range)
7C68A2   390  -48.3   -43.3  -46.2     5.0   (steady, distant)
7C7794   327  -48.0   -42.0  -45.6     6.0   (steady, distant)
7C1C55   241  -48.1   -37.4  -46.0    10.7   (some range change)
7C68B9    52  -48.2   -47.3  -47.8     0.9   (steady, far)
```

Aircraft holding roughly constant range show tight clusters (0.9-6 dB
spread -- consistent with normal fluctuation at stable distance), while
an aircraft with real range change shows a correspondingly wide spread.
Zero bounds-check rejections in this session. Separately, a close pass
(~2.4nm) showed RSSI in the -18 to -35 dBFS range depending on aspect,
which is a believable range for the receive chain (discone antenna, not
a tuned 1090MHz-specific antenna -- so somewhat below the -3 to -15 dBFS
"strong" range you'd see with dedicated gear, but in the right
ballpark). Before the `signal_len` correction, RSSI for every aircraft
at every distance clustered within ~0.5 dB of each other regardless of
range -- i.e., we were consistently reading noise floor.

## MLAT disclaimer -- please read before merging

**The MLAT timestamp correction has NOT been independently verified.**
Neither of us runs MLAT, so there's no way for us to confirm it against
a real multilateration setup. The reasoning is sound and follows
directly from the RSSI evidence above (same `position` variable, same
demonstrated meaning), but "sound reasoning" isn't the same as
"verified." If anyone reviewing this has an MLAT-feeding setup on
SDRplay/8MHz, it would be very helpful if you could check MLAT position
accuracy before and after this change and report back -- happy to
adjust or revert that part specifically if it doesn't hold up in
practice, independent of the RSSI fix.

## Testing

Built and run live against an SDRplay RSP2pro across several sessions.
RSSI verified two ways: (1) a temporary raw-magnitude-window diagnostic
confirming the real signal burst lands within the read window after the
fix (previously it consistently ended right where the window began);
(2) aggregate RSSI-vs-distance sanity checks across multiple aircraft,
shown above. MLAT timestamp change is code-reasoned from the same
evidence but not independently tested.